### PR TITLE
DevFest 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@
 * **Local:** Faculdade Senac, Porto Alegre-RS
 * **Tags:** php, cake
 
+#### [DevFest 2018 Feira de Santana](https://gdgfsa.github.io/devfest2018/) (2018-12-08)
+* **Data:** 08/12/2018
+* **Local:** Faculdade de Tecnologia e Ciências, Feira de Santana-BA
+* **Tags:** GDG, DevFest, Flutter, Google
+
 #### [RubyConf Brasil](https://eventos.locaweb.com.br/proximos-eventos/rubyconf-brasil-2018/) (2018-12-13)
 * **Data:** 13/12/2018 a 14/12/2018
 * **Local:** Universidade Anhembi Morumbi, São Paulo-SP


### PR DESCRIPTION
DevFest 2018 organizado pelo GDG Feira de Santana. Será dia 8 de dezembro no campus da FTC. Mais informações no [site](https://gdgfsa.github.io/devfest2018/).