### PR TITLE
python for all 2019

### DIFF
--- a/2019.md
+++ b/2019.md
@@ -40,6 +40,12 @@
 
 ## Junho
 
+#### [Python For All](http://www.pythonforall.com) (2019-06-1)
+* **Data:** 01/06/2019 a 02/06/2019
+* **Local:** Feira de Santana, BA
+* **Tags:** python, web, big data, data science, deep learning  
+
+
 ## Julho
 
 #### [XXXIX Congresso da Sociedade Brasileira de Computação](http://www.sbc.org.br/csbc2019) (2018-07-14)


### PR DESCRIPTION
Python For All 2019, 1 e 2 de junho de 2019
Feira de Santana , BA
www.pythonforall.com.br